### PR TITLE
Compatibility updates + removal of cargo-build dependency

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+target = "3ds"
+
+[target.3ds]
+linker = "arm-none-eabi-gcc"

--- a/3ds.json
+++ b/3ds.json
@@ -29,7 +29,6 @@
     "-lsysbase",
     "-lc",
     "-lm",
-    "-lcompiler-rt",
     "-lsysbase",
     "-lgcc",
     "-lc",

--- a/3ds.json
+++ b/3ds.json
@@ -1,5 +1,5 @@
 {
-  "data-layout": "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:64:128-a:0:64-n32-m:e",
+  "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", 
   "llvm-target": "arm-none-eabihf",
   "linker": "arm-none-eabi-gcc",
   "ar": "arm-none-eabi-ar",
@@ -18,19 +18,22 @@
   "dynamic-linking": false,
   "no-compiler-rt": true,
   "exe-suffix": ".elf",
-  "pre-link-args": ["-specs=3dsx.specs",
+  "pre-link-args": [
+    "-specs=3dsx.specs",
     "-march=armv6k",
     "-mtune=mpcore",
-    "-mfloat-abi=hard"
+    "-mfloat-abi=hard",
+    "-mtp=soft"
   ],
   "post-link-args": [
-      "-lsysbase",
-      "-lc",
-      "-lcompiler-rt",
-      "-lsysbase",
-      "-lgcc",
-      "-lc",
-      "-lsysbase"
+    "-lsysbase",
+    "-lc",
+    "-lm",
+    "-lcompiler-rt",
+    "-lsysbase",
+    "-lgcc",
+    "-lc",
+    "-lsysbase"
   ],
   "is-like-windows": false,
   "function-sections": false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,9 @@ name = "rust3ds-template"
 version = "0.1.0"
 build = "build.rs"
 
-[dependencies.alloc_system3ds]
-git = "https://github.com/Furyhunter/alloc_system3ds"
-
-[dependencies.ctru-rs]
-path = "../ctru-rs"
+[dependencies]
+ctru-rs = { git = "https://github.com/Furyhunter/ctru-rs", rev = "7337abc" } 
+alloc_system3ds = { git = "https://github.com/Furyhunter/alloc_system3ds" }
 
 [profile.dev]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 description = "Nintendo 3DS project template"
 
 [dependencies.ctru-rs]
-git = "https://github.com/FenrirWolf/ctru-rs"
+git = "https://github.com/Furyhunter/ctru-rs"
 
 [dependencies.alloc_system3ds]
-git = "https://github.com/FenrirWolf/alloc_system3ds"
+git = "https://github.com/Furyhunter/alloc_system3ds"
 
 [profile.dev]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 description = "Nintendo 3DS project template"
 name = "rust3ds-template"
 version = "0.1.0"
+build = "build.rs"
 
 [dependencies.alloc_system3ds]
 git = "https://github.com/Furyhunter/alloc_system3ds"
@@ -11,6 +12,8 @@ path = "../ctru-rs"
 
 [profile.dev]
 lto = true
+panic = 'abort'
 
 [profile.release]
 lto = true
+panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
+description = "Nintendo 3DS project template"
 name = "rust3ds-template"
 version = "0.1.0"
-description = "Nintendo 3DS project template"
-
-[dependencies.ctru-rs]
-git = "https://github.com/Furyhunter/ctru-rs"
 
 [dependencies.alloc_system3ds]
 git = "https://github.com/Furyhunter/alloc_system3ds"
+
+[dependencies.ctru-rs]
+path = "../ctru-rs"
 
 [profile.dev]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 description = "Nintendo 3DS project template"
 
 [dependencies.ctru-rs]
-git = "https://github.com/Furyhunter/ctru-rs"
+git = "https://github.com/FenrirWolf/ctru-rs"
 
 [dependencies.alloc_system3ds]
-git = "https://github.com/Furyhunter/alloc_system3ds"
+git = "https://github.com/FenrirWolf/alloc_system3ds"
 
 [profile.dev]
 lto = true

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,12 @@ ifeq ($(strip $(RUST_3DS_SYSROOT)),)
 	RUST_3DS_SYSROOT := sysroot
 endif
 
-RUST_FLAGS := RUSTFLAGS="--sysroot sysroot -C panic=abort -Z no-landing-pads"
-#CARGO_FLAGS := --verbose 
-
 .PHONY: all clean $(CRATE_NAME) dist sysroot test target/3ds/release/$(CRATE_NAME).elf
 
 all: $(CRATE_NAME) 
 
 target/3ds/release/$(CRATE_NAME).elf:
-	$(RUST_FLAGS) cargo build --release --target "3ds.json" $(CARGO_FLAGS) 
+	xargo build --release
 
 target/3ds/release/$(CRATE_NAME).smdh:
 	$(SMDHTOOL) --create "${PROG_NAME}" "${PROG_DESC}" "${PROG_AUTHOR}" "${PROG_ICON}" target/3ds/release/$(CRATE_NAME).smdh
@@ -40,28 +37,7 @@ dist: $(CRATE_NAME)
 
 test: $(CRATE_NAME)
 	citra target/3ds/release/$(CRATE_NAME).elf
-	
 
 clean:
 	rm -rf target
 	rm -rf dist
-
-# Useful targets
-
-sysroot: sysroot/lib/rustlib/3ds.json/lib/libcore.rlib \
-		sysroot/lib/rustlib/3ds.json/lib/liballoc.rlib \
-		sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib \
-		sysroot/lib/rustlib/3ds.json/lib/librustc_unicode.rlib \
-		sysroot/lib/rustlib/3ds.json/lib/libcollections.rlib \
-
-sysroot/lib/rustlib/3ds.json/lib:
-	@mkdir -p sysroot/lib/rustlib/3ds.json/lib
-
-sysroot/lib/rustlib/3ds.json/lib/%.rlib: sysroot/lib/rustlib/3ds.json/lib
-	@echo Building $*
-	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/$*.rlib --sysroot $(RUST_3DS_SYSROOT) $(RUST_SRC_PATH)/$*/lib.rs -C panic=abort -Z no-landing-pads
-
-sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib: 
-	@echo Building liblibc
-	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib --sysroot $(RUST_3DS_SYSROOT) --cfg stdbuild $(RUST_SRC_PATH)/liblibc/src/lib.rs -Z no-landing-pads
-

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,8 @@ sysroot/lib/rustlib/3ds.json/lib:
 sysroot/lib/rustlib/3ds.json/lib/%.rlib: sysroot/lib/rustlib/3ds.json/lib
 	@echo Building $*
 	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/$*.rlib --sysroot $(RUST_3DS_SYSROOT) --cfg target_os,linux $(RUST_SRC_PATH)/$*/lib.rs -Z no-landing-pads
+
+sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib: 
+	@echo Building liblibc
+	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib --sysroot $(RUST_3DS_SYSROOT) --cfg stdbuild --cfg target_os,linux $(RUST_SRC_PATH)/liblibc/src/lib.rs -Z no-landing-pads
+

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ ifeq ($(strip $(RUST_3DS_SYSROOT)),)
 	RUST_3DS_SYSROOT := sysroot
 endif
 
-RUST_FLAGS := RUSTFLAGS="--sysroot sysroot -Z no-landing-pads"
+RUST_FLAGS := RUSTFLAGS="--sysroot sysroot -C panic=abort -Z no-landing-pads"
 #CARGO_FLAGS := --verbose 
 
-.PHONY: all clean $(CRATE_NAME) dist sysroot target/3ds/release/$(CRATE_NAME).elf
+.PHONY: all clean $(CRATE_NAME) dist sysroot test target/3ds/release/$(CRATE_NAME).elf
 
 all: $(CRATE_NAME) 
 
@@ -38,6 +38,10 @@ dist: $(CRATE_NAME)
 	cp target/3ds/release/$(CRATE_NAME).smdh dist/$(CRATE_NAME)
 	cp $(PROG_ICON) dist/$(CRATE_NAME)/$(CRATE_NAME).png
 
+test: $(CRATE_NAME)
+	citra target/3ds/release/$(CRATE_NAME).elf
+	
+
 clean:
 	rm -rf target
 	rm -rf dist
@@ -55,7 +59,7 @@ sysroot/lib/rustlib/3ds.json/lib:
 
 sysroot/lib/rustlib/3ds.json/lib/%.rlib: sysroot/lib/rustlib/3ds.json/lib
 	@echo Building $*
-	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/$*.rlib --sysroot $(RUST_3DS_SYSROOT) $(RUST_SRC_PATH)/$*/lib.rs -Z no-landing-pads
+	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/$*.rlib --sysroot $(RUST_3DS_SYSROOT) $(RUST_SRC_PATH)/$*/lib.rs -C panic=abort -Z no-landing-pads
 
 sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib: 
 	@echo Building liblibc

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,15 @@ ifeq ($(strip $(RUST_3DS_SYSROOT)),)
 	RUST_3DS_SYSROOT := sysroot
 endif
 
+RUST_FLAGS := RUSTFLAGS="--sysroot sysroot -Z no-landing-pads"
+#CARGO_FLAGS := --verbose 
+
 .PHONY: all clean $(CRATE_NAME) dist sysroot target/3ds/release/$(CRATE_NAME).elf
 
-all: $(CRATE_NAME)
+all: $(CRATE_NAME) 
 
 target/3ds/release/$(CRATE_NAME).elf:
-	$(CARGO_BUILD) --release --sysroot $(RUST_3DS_SYSROOT) --target "3ds.json" $(CARGO_FLAGS) -- -Z no-landing-pads
+	$(RUST_FLAGS) cargo build --release --target "3ds.json" $(CARGO_FLAGS) 
 
 target/3ds/release/$(CRATE_NAME).smdh:
 	$(SMDHTOOL) --create "${PROG_NAME}" "${PROG_DESC}" "${PROG_AUTHOR}" "${PROG_ICON}" target/3ds/release/$(CRATE_NAME).smdh
@@ -45,16 +48,16 @@ sysroot: sysroot/lib/rustlib/3ds.json/lib/libcore.rlib \
 		sysroot/lib/rustlib/3ds.json/lib/liballoc.rlib \
 		sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib \
 		sysroot/lib/rustlib/3ds.json/lib/librustc_unicode.rlib \
-		sysroot/lib/rustlib/3ds.json/lib/libcollections.rlib
+		sysroot/lib/rustlib/3ds.json/lib/libcollections.rlib \
 
 sysroot/lib/rustlib/3ds.json/lib:
 	@mkdir -p sysroot/lib/rustlib/3ds.json/lib
 
 sysroot/lib/rustlib/3ds.json/lib/%.rlib: sysroot/lib/rustlib/3ds.json/lib
 	@echo Building $*
-	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/$*.rlib --sysroot $(RUST_3DS_SYSROOT) --cfg target_os,linux $(RUST_SRC_PATH)/$*/lib.rs -Z no-landing-pads
+	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/$*.rlib --sysroot $(RUST_3DS_SYSROOT) $(RUST_SRC_PATH)/$*/lib.rs -Z no-landing-pads
 
 sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib: 
 	@echo Building liblibc
-	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib --sysroot $(RUST_3DS_SYSROOT) --cfg stdbuild --cfg target_os,linux $(RUST_SRC_PATH)/liblibc/src/lib.rs -Z no-landing-pads
+	@rustc --target 3ds.json -o sysroot/lib/rustlib/3ds.json/lib/liblibc.rlib --sysroot $(RUST_3DS_SYSROOT) --cfg stdbuild $(RUST_SRC_PATH)/liblibc/src/lib.rs -Z no-landing-pads
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@ A project template for Rust projects to be built on the Nintendo 3DS Homebrew La
 
 ## What you need
 
-First of all, you need to be running a Nightly build of Rust. This project will NOT currently compile on Stable Rust. 
+First of all, you need to be running a Nightly build of Rust. This project will NOT currently compile on Stable Rust.
 
-You will also need to download the Rust Nightly source (making sure that the source you download is the same version as the Rust build you are actually running) and save it to your computer. Both the Nightly builds and the source code can be found at the bottom of the page [here](https://www.rust-lang.org/downloads.html). 
+Secondly, you need to install [Xargo](https://github.com/japaric/xargo). All you have to do is type `cargo install xargo` into your terminal and wait for it to compile.
 
-You will also need the following:
- * [devkitARM](http://sourceforge.net/projects/devkitpro/files/devkitARM/). A more detailed tutorial on how to set up dkA for the 3DS can be found [here](http://3dbrew.org/wiki/Setting_up_Development_Environment)
- * `libcompiler-rt.a` for 3ds. This is already provided in the 'sysroot' folder.
- * `libcore` compiled from Rust source code you downloaded above. Instructions on how to build libcore (and other rust libraries) for the 3ds are detailed later in this readme.
+Finally, you will need to install [devkitARM](http://sourceforge.net/projects/devkitpro/files/devkitARM/). A more detailed tutorial on how to set up dkA for the 3DS can be found [here](http://3dbrew.org/wiki/Setting_up_Development_Environment)
 
 
 ## Environment configuration
@@ -25,25 +22,21 @@ The following environment variables need to be set:
  
 These should already be in place if you've properly installed devkitARM. If you missed that step somewhere along the line, refer again to the [3DS homebrew environment setup tutorial](http://3dbrew.org/wiki/Setting_up_Development_Environment)
  
- * `$RUST_SRC_PATH` -- path to the `src` folder of the Rust source code you downloaded above. This is required so that you can build libcore as detailed below.
-
 
 ## Building libcore (and friends) for the 3ds
 
-Instead of invoking Cargo directly, you should use the included Makefile to start building your 3ds code. Before you can compile your project, you need to use the Make command `make sysroot` to build 3ds versions of the following libraries:
+When you build your program using `xargo build` instead of `cargo build`, a custom 3DS-compatible sysroot will be compiled. While the full Rust standard libary is currently unavailable, the following crates are able to be used in your project: 
 
  * `core` -- platform-agnostic basics + prelude
  * `alloc` -- memory allocation functions
- * `libc` -- libc bindings. note: using some functions may result in undefined symbols
  * `rustc_unicode` -- unicode stuff
  * `collections` -- std collections (requires `alloc`, `rustc_unicode`)
 
 Allocators are provided by a simple implementation of `alloc_system`. This means that `Box` is available, so `collections` will work in its entirety.
-**Notably, libstd is not currently available. It requires some unwinding features that are not (yet?) possible to implement for the 3ds.**
 
 
 ## Building your 3ds homebrew project
 
-Simply run the `make` command and, if everything is all set up properly, your homebrew project will compile!
+Run `xargo build` or `xargo build --release` and a 3DS-compatible elf file will be generated. Additionally, you can simply run the `make` command and a Homebrew Launcher-compatible 3dsx file will also be created.
 
-Other useful commands are `make clean` to clear out old build artifacts and `make dist` to put the resulting 3ds homebrew files in an easily distributable folder.
+Other useful Make commands are `make clean` to clear out old build artifacts and `make dist` to put the resulting 3ds homebrew files in an easily distributable folder.

--- a/README.md
+++ b/README.md
@@ -2,41 +2,52 @@
 
 A project template for Rust projects to be built on the Nintendo 3DS Homebrew Launcher.
 
+
 ## What you need
 
- * devKitARM
- * Rust nightly (1.4 as of this writing)
- * [my modified `cargo-build`](https://github.com/Furyhunter/cargo-build) -- subject to change if changes get merged.
- * `libcore` compiled from Rust sources. Instructions below on building.
- * `libcompiler-rt.a` for 3ds. Provided in sysroot folder. Use the sysroot target to build the rust dependency libraries as mentioned below, and everything should work automatically.
+First of all, you need to be running a Nightly build of Rust. This project will NOT currently compile on Stable Rust. 
 
-## Environment configuration
+You will also need to download the Rust Nightly source (making sure that the source you download is the same version as the Rust build you are actually running) and save it to your computer. Both the Nightly builds and the source code can be found at the bottom of the page [here](https://www.rust-lang.org/downloads.html). 
 
-The file `~/.cargo/config` must be created with these contents:
+You will also need the following:
+ * [devkitARM](http://sourceforge.net/projects/devkitpro/files/devkitARM/). A more detailed tutorial on how to set up dkA for the 3DS can be found [here](http://3dbrew.org/wiki/Setting_up_Development_Environment)
+ * [my modified `cargo-build`](https://github.com/Furyhunter/cargo-build). Compile the program and put the resulting binary somewhere in your PATH so that you can freely run it from the command line.
+ * `libcompiler-rt.a` for 3ds. This is already provided in the 'sysroot' folder.
+ * `libcore` compiled from Rust source code you downloaded above. Instructions on how to build libcore (and other rust libraries) for the 3ds are detailed later in this readme.
+
+
+## Cargo configuration
+
+The included target file `3ds.json` handles most of the configuration settings required for Cargo to cross-compile Rust code to the 3ds. However, the Archiver for DevKitPRO has to be manually specified in Cargo's configuration settings. Otherwise the system `ar` will be used instead, and you'll get sad linker errors.
+
+The default location for Cargo's config file is in `~/.cargo/config`. Edit this file (or create it if it doesn't exist) and add the following to it:
 
 ```toml
 [target.3ds]
 ar = "/path/to/arm-none-eabi-ar"
 ```
 
-The archiver is not settable using target json, so you have to set this
-manually. Otherwise the system `ar` will be used, and you'll get sad linker
-errors.
+
+## Environment configuration
 
 The following environment variables need to be set:
 
  * `$DEVKITPRO`
  * `$DEVKITARM`
  * `$CTRULIB`
- * `$RUST_3DS_SYSROOT` - path to sysroot such that `libcore.rlib` is located in the path `lib/rustlib/3ds.json/lib/libcore.rlib`. This is set to `sysroot` by default. **You can use the sysroot target to generate the necessary libcore locally; see below**
- * `$CARGO_BUILD` - path to `cargo-build` binary
+ 
+These should already be in place if you've properly installed devkitARM. If you missed that step somewhere along the line, refer again to the [3DS homebrew environment setup tutorial](http://3dbrew.org/wiki/Setting_up_Development_Environment)
+ 
+ * `$RUST_3DS_SYSROOT` - path to sysroot such that `libcore.rlib` is located in the path `lib/rustlib/3ds.json/lib/libcore.rlib`. This is already set to the included `sysroot` folder by default in the Makefile.
 
-The sysroot libraries can be generated using the `sysroot` target. For that, you need to set this environment variable:
+ * `$CARGO_BUILD` - path to the `cargo-build` binary that you built earlier.
 
- * `$RUST_SRC_PATH` -- path to `src` of rust checkout
+ * `$RUST_SRC_PATH` -- path to the `src` folder of the Rust source code you downloaded above. This is required so that you can build libcore as detailed below.
 
-The following rustc libraries can be built. **Notably, libstd is not currently
-available. It requires some unwinding features that are not possible.**
+
+## Building libcore (and friends) for the 3ds
+
+Instead of invoking Cargo directly, you should use the included Makefile to start building your 3ds code. Before you can compile your project, you need to use the Make command `make sysroot` to build 3ds versions of the following libraries:
 
  * `core` -- platform-agnostic basics + prelude
  * `alloc` -- memory allocation functions
@@ -44,4 +55,12 @@ available. It requires some unwinding features that are not possible.**
  * `rustc_unicode` -- unicode stuff
  * `collections` -- std collections (requires `alloc`, `rustc_unicode`)
 
-The make target `sysroot` automatically builds these. Allocators are provided by a simple implementation of `alloc_system`. This means that `Box` is available, so `collections` will work in its entirety.
+Allocators are provided by a simple implementation of `alloc_system`. This means that `Box` is available, so `collections` will work in its entirety.
+**Notably, libstd is not currently available. It requires some unwinding features that are not (yet?) possible to implement for the 3ds.**
+
+
+## Building your 3ds homebrew project
+
+Simply run the `make` command and, if everything is all set up properly, your homebrew project will compile!
+
+Other useful commands are `make clean` to clear out old build artifacts and `make dist` to put the resulting 3ds homebrew files in an easily distributable folder.

--- a/README.md
+++ b/README.md
@@ -11,21 +11,8 @@ You will also need to download the Rust Nightly source (making sure that the sou
 
 You will also need the following:
  * [devkitARM](http://sourceforge.net/projects/devkitpro/files/devkitARM/). A more detailed tutorial on how to set up dkA for the 3DS can be found [here](http://3dbrew.org/wiki/Setting_up_Development_Environment)
- * [my modified `cargo-build`](https://github.com/Furyhunter/cargo-build). Compile the program and put the resulting binary somewhere in your PATH so that you can freely run it from the command line.
  * `libcompiler-rt.a` for 3ds. This is already provided in the 'sysroot' folder.
  * `libcore` compiled from Rust source code you downloaded above. Instructions on how to build libcore (and other rust libraries) for the 3ds are detailed later in this readme.
-
-
-## Cargo configuration
-
-The included target file `3ds.json` handles most of the configuration settings required for Cargo to cross-compile Rust code to the 3ds. However, the Archiver for DevKitPRO has to be manually specified in Cargo's configuration settings. Otherwise the system `ar` will be used instead, and you'll get sad linker errors.
-
-The default location for Cargo's config file is in `~/.cargo/config`. Edit this file (or create it if it doesn't exist) and add the following to it:
-
-```toml
-[target.3ds]
-ar = "/path/to/arm-none-eabi-ar"
-```
 
 
 ## Environment configuration
@@ -38,10 +25,6 @@ The following environment variables need to be set:
  
 These should already be in place if you've properly installed devkitARM. If you missed that step somewhere along the line, refer again to the [3DS homebrew environment setup tutorial](http://3dbrew.org/wiki/Setting_up_Development_Environment)
  
- * `$RUST_3DS_SYSROOT` - path to sysroot such that `libcore.rlib` is located in the path `lib/rustlib/3ds.json/lib/libcore.rlib`. This is already set to the included `sysroot` folder by default in the Makefile.
-
- * `$CARGO_BUILD` - path to the `cargo-build` binary that you built earlier.
-
  * `$RUST_SRC_PATH` -- path to the `src` folder of the Rust source code you downloaded above. This is required so that you can build libcore as detailed below.
 
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-lib=static=compiler-rt");
+    println!("cargo:rustc-link-search=native=sysroot/lib/rustlib/3ds.json/lib/");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ pub extern "C" fn main(_: isize, _: *const *const u8) -> isize {
     0
 }
 
-fn main_3ds() -> () {
+fn main_3ds() {
     use ctru::gfx::Screen;
     use ctru::services::gspgpu::FramebufferFormat;
     use ctru::services::hid::PadKey;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
 
 #[macro_use]
 extern crate ctru;
-use ctru::prelude::*;
 
 use ctru::Gfx;
 use ctru::console::Console;
@@ -17,6 +16,7 @@ pub extern "C" fn main(_: isize, _: *const *const u8) -> isize {
 }
 
 fn main_3ds() {
+    use core::fmt::Write;
     use ctru::gfx::Screen;
     use ctru::services::gspgpu::FramebufferFormat;
     use ctru::services::hid::PadKey;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,102 +1,44 @@
 #![feature(start)]
-#![feature(alloc)]
-#![feature(collections)]
 #![no_main]
 #![no_std]
 
+#[macro_use]
 extern crate ctru;
-extern crate alloc;
-#[macro_use] extern crate collections;
+use ctru::prelude::*;
 
-use ctru::{Srv, Gfx};
-use ctru::services::{Hid, Apt, Application};
+use ctru::Gfx;
+use ctru::console::Console;
+use ctru::services::{Hid, Apt};
 use ctru::services::hid::PadKey;
-use ctru::services::gsp;
 
 #[no_mangle]
-pub extern fn main(_: isize, _: *const *const u8) -> isize {
+pub extern "C" fn main(_: isize, _: *const *const u8) -> isize {
     main_3ds();
     0
 }
 
-struct MyApplication {
-    hid: Hid,
-    gfx: Gfx,
-    running: bool
-}
-
-impl Application for MyApplication {
-    fn main_loop(&mut self, _: &mut Apt) {
-        use ctru::gfx::{Screen, Side};
-
-        let (fb, _, _) = self.gfx.get_framebuffer(Screen::Top, Side::Left);
-        let (rfb, _, _) = self.gfx.get_framebuffer(Screen::Top, Side::Right);
-        let (bfb, _, _) = self.gfx.get_framebuffer(Screen::Bottom, Side::Left);
-
-        let topdepth = self.gfx.get_framebuffer_format(Screen::Top).pixel_depth_bytes();
-        let botdepth = self.gfx.get_framebuffer_format(Screen::Bottom).pixel_depth_bytes();
-
-        gsp::wait_for_event(gsp::Event::VBlank0);
-        for i in fb.chunks_mut(topdepth) {
-            i[0] = 127u8;
-            i[1] = 127u8;
-            i[2] = 127u8;
-        }
-        for i in rfb.chunks_mut(topdepth) {
-            i[0] = 0u8;
-            i[1] = 127u8;
-            i[2] = 255u8;
-        }
-        for i in bfb.chunks_mut(botdepth) {
-            i[0] = 255u8;
-            i[1] = 127u8;
-            i[2] = 0u8;
-
-        }
-        self.gfx.flush_buffers();
-        self.gfx.swap_buffers();
-
-        self.hid.scan_input();
-        if self.hid.key_down(PadKey::Start) {
-            self.running = false;
-        }
-    }
-
-    fn ready_to_quit(&self) -> bool { !self.running }
-}
-
 fn main_3ds() -> () {
     use ctru::gfx::Screen;
-    use ctru::services::gsp::FramebufferFormat;
+    use ctru::services::gspgpu::FramebufferFormat;
 
-    let srv = match Srv::new() {
-        Ok(s) => s,
-        _ => return
-    };
-    let mut apt = match Apt::new() {
-        Ok(a) => a,
-        _ => return
-    };
-    let hid = match Hid::new() {
-        Ok(h) => h,
-        _ => return
-    };
+    let mut apt = Apt::new();
+    let mut hid = Hid::new();
     let mut gfx = Gfx::default();
 
     gfx.set_framebuffer_format(Screen::Top, FramebufferFormat::Bgr8);
     gfx.set_framebuffer_format(Screen::Bottom, FramebufferFormat::Bgr8);
 
-    gfx.set_3d_enabled(true);
+    let mut console = Console::default();
 
-    let mut myapp = MyApplication {
-        hid: hid,
-        gfx: gfx,
-        running: true
-    };
+    console.println("Hello, this is a walrus!");
 
-    apt.main_loop(&mut myapp);
+    while apt.main_loop() {
+        gfx.flush_buffers();
+        gfx.swap_buffers();
 
-    drop(myapp);
-    drop(apt);
-    drop(srv);
+        hid.scan_input();
+        if hid.key_down(PadKey::Start) {
+            break;
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(no_std)]
 #![feature(start)]
 #![feature(alloc)]
 #![feature(collections)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use ctru::prelude::*;
 use ctru::Gfx;
 use ctru::console::Console;
 use ctru::services::{Hid, Apt};
-use ctru::services::hid::PadKey;
 
 #[no_mangle]
 pub extern "C" fn main(_: isize, _: *const *const u8) -> isize {
@@ -20,6 +19,7 @@ pub extern "C" fn main(_: isize, _: *const *const u8) -> isize {
 fn main_3ds() -> () {
     use ctru::gfx::Screen;
     use ctru::services::gspgpu::FramebufferFormat;
+    use ctru::services::hid::PadKey;
 
     let mut apt = Apt::new();
     let mut hid = Hid::new();
@@ -30,7 +30,7 @@ fn main_3ds() -> () {
 
     let mut console = Console::default();
 
-    console.println("Hello, this is a walrus!");
+    writeln!(&mut console, "Hello, {}", "world!").unwrap();
 
     while apt.main_loop() {
         gfx.flush_buffers();


### PR DESCRIPTION
In addition to compatibility with nightly rust 1.10.0, I removed the need for cargo-build by taking advantage of $RUSTFLAGS. The user is still required to build the sysroot but the Makefile takes care of it.